### PR TITLE
Highlight Favorites

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -105,7 +105,8 @@ function getGeneralOptions() {
 		chrome.storage.sync.get({
 			'generalOptions': {
 				showBadge: true,
-				favoriteFriends: []
+				favoriteFriends: [],
+				highlightFavories: false
 			}
 		}, function(data) {
 			resolve(data);

--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -118,7 +118,7 @@ $(() => {
 		}	
 
 		// If the user desires to have favorites highlighted:
-		if(settings.homePageOptions.highlightFavorites){
+		if(settings.generalOptions.highlightFavorites){
 			if(cache.highlightLoop != null) {
 				clearInterval(cache.highlightLoop);
 			}
@@ -133,13 +133,10 @@ $(() => {
 					// Which streamer did we find
 					var streamer = $(this).find("h2.username").text().replace(/ /g, '').replace(/\r?\n|\r/g, "");
 					
-					if (favoriteFriends != null) {
-						if (favoriteFriends.indexOf(streamer) >= 0) {
-							// If streamer is a favorite, let's highlight the window
-							//log("Found '"+streamer+'"! Highlighting window.')
-							$(this).find("h2.username").addClass("favoriteUsername");
-							$(this).addClass("favoriteFriend");
-						}
+					if (streamerIsFavorited(streamer)) {
+						// If streamer is a favorite, let's highlight the window
+						$(this).find("h2.username").addClass("favoriteUsername");
+						$(this).addClass("favoriteFriend");
 					}
 				});
 			}, 500);
@@ -153,9 +150,125 @@ $(() => {
 			}
 		}
 	}
+
+	function showFavoriteButton(isFavorited) {
+		if (isFavorited == "") {
+			isFavorited = false;
+		}
+
+		if (isFavorited) {
+			$("div.owner-block h2:first-of-type").addClass("favoriteUsername");
+			$("<div id=\"ME_favorite-btn\">&#9733;</div>").insertAfter("div.follow-block");
+			$("#ME_favorite-btn").addClass("faved");
+		} else {
+			$("div.owner-block h2:first-of-type").removeClass("favoriteUsername");
+			$("<div id=\"ME_favorite-btn\">&#9734;</div>").insertAfter("div.follow-block");
+			$("#ME_favorite-btn").removeClass("faved");
+		}
+
+	}
+
+	function setFavoriteButtonState(isFavorited) {
+		if (isFavorited == "") {
+			isFavorited = false;
+		}
+
+		// Removing the favorite button to avoid any duplication
+		$("#ME_favorite-btn").remove();
+
+		if (isFavorited) {
+			//
+			$("#ME_favorite-btn").html("&#9733;");
+			$("div.owner-block h2:first-of-type").addClass("favoriteUsername");
+			$("#ME_favorite-btn").addClass("faved");
+		} else {
+			$("#ME_favorite-btn").html("&#9734;");
+			$("div.owner-block h2:first-of-type").removeClass("favoriteUsername");
+			$("#ME_favorite-btn").removeClass("faved");
+		}
+	}
+
+	function getChannelNameById(id) {
+		return new Promise((resolve, reject) => {
+			var request = new XMLHttpRequest();
+			request.open('GET', `https://mixer.com/api/v1/channels/${id}`, true);
+	
+			request.onload = function() {
+				if (request.status >= 200 && request.status < 400) {
+					// Success!
+					var data = JSON.parse(request.responseText);
+					resolve(data.token);
+				} else {
+					reject('Error getting channel details');
+				}
+			};
+	
+			request.onerror = function() {
+				// There was a connection error of some sort
+				reject('Error getting channel details');
+			};
+	
+			request.send();
+		});
+	}
 	
 	function loadStreamerPage(streamerName) {
 		log(`Loading streamer page for: ${streamerName}`);
+
+		// If the user desires to have favorites highlighted, we need to active the :
+		if(settings.generalOptions.highlightFavorites){
+			log("Starting working on the highlight + fav button");
+
+			// Let's if we are following this person
+			isFollowed = streamerIsFollowed(streamerName);
+
+			// Once we get some info back from the API
+			isFollowed.then((result) => {
+				if (result) {
+					// If the streamer is followed,
+					// Let's show the favorite button, but it's state is based on whether streamed is faved.
+					showFavoriteButton(streamerIsFavorited(streamerName));
+
+					// We now set some actions to the button we just added.
+					// These toggle the favorite status of the streamer, as well the button's state.
+					$("#ME_favorite-btn").click( function () {
+						addOrRemoveFavorite(streamerName);
+						setFavoriteButtonState(streamerIsFavorited(streamerName));
+					});
+
+					// Also need to set an action that either detects if the streamer is no longer followed, or pays attention to the unfollow action.
+					// If user unfollows, favorite status needs to be removed.
+				} else {
+					// User doesn't follow the streamer.
+					// There's stuff to do here that I haven't figured out yet.
+
+					// If not followed, favorite status should be removed automatically.
+
+					// We should also attach an event to the follow button that will make the favorite button appear when a streamer is followed.
+					$('bui-icon[icon="heart-full"]').closest('div.bui-btn-raised').click(function () {
+						log('Now following current streamer!');
+						showFavoriteButton(streamerIsFavorited(streamerName));
+
+						$("#ME_favorite-btn").click( function () {
+							addOrRemoveFavorite(streamerName);
+							setFavoriteButtonState(streamerIsFavorited(streamerName));
+						});
+
+						$('bui-icon[icon="heart-full"]').closest('div.bui-btn-raised').off('click');
+					});
+				}
+			});
+
+			
+
+
+			
+
+		} else {
+			log("Highlights not active. So we don't do this.")
+			$("div.owner-block h2:first-of-type").removeClass("favoriteUsername");
+			$("#ME_favorite-btn").removeClass("faved");
+		}
 	
 		if(!settings.streamerPageOptions) {
 			log('No streamer page settings saved.');
@@ -661,6 +774,90 @@ $(() => {
 					resolve(null);
 				});
 		});
+	}
+
+	function streamerIsFollowed(streamerName) {
+		return new Promise((resolve, reject) => {
+			// get id and do something with it
+			if (cache.user != null) {
+				var userId = cache.user.id;
+				log("current userID: " + userId);
+				log(`https://mixer.com/api/v1/users/${userId}/follows?fields=token&where=token:eq:${streamerName}`);
+
+				var request = new XMLHttpRequest();
+				request.open('GET', `https://mixer.com/api/v1/users/${userId}/follows?fields=token&where=token:eq:${streamerName}`, true);
+		
+				request.onload = function() {
+					if (request.status >= 200 && request.status < 400) {
+						// Success!
+						//var data = JSON.parse(request.responseText);
+						var data = JSON.parse(request.responseText);
+						console.log(data);
+
+						if (data.length > 0) {
+							log(`${streamerName} is followed`)
+							resolve(true);
+						} else {
+							log(`${streamerName} is not followed`)
+							resolve(false);
+						}
+						//if (data.)
+						//resolve(true);
+					} else {
+						var data = JSON.parse(request.responseText);
+						console.log(data);
+						reject(false);
+					}
+				};
+		
+				request.onerror = function() {
+					// There was a connection error of some sort
+					reject(false);
+				};
+		
+				request.send();
+			
+			} else {
+				reject(false);
+			}
+		});
+	}
+
+	// Returns boolean based on whether or not a streamer is favorited.
+	function streamerIsFavorited(streamerName) {
+		favoriteFriends = settings.generalOptions.favoriteFriends;
+
+		// Is there data in the friends array?
+		if (favoriteFriends != null) {
+			// If there is data, is there anything in it?
+			if (favoriteFriends.indexOf(streamerName) >= 0) {
+				// If streamer is a favorite, then we want.
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// Adds or Removes a streamer to the favorite list
+	function addOrRemoveFavorite(streamerName) {
+		favorites = settings.generalOptions.favoriteFriends;
+		if (streamerIsFavorited(streamerName)) {
+			log("Removing: "+streamerName);
+			const index = favorites.indexOf(streamerName);
+
+			if (index !== -1) {
+				favorites.splice(index, 1);
+			}
+		} else {
+			favorites.push(streamerName);
+			log("Adding: "+streamerName);
+		}
+
+		chrome.storage.sync.set({
+			'generalOptions': {
+				favoriteFriends: favorites
+			}
+		}, () => {});
 	}
 	
 	waitForPageLoad().then(() => {

--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -116,6 +116,42 @@ $(() => {
 			$('.home').scrollTop($('.home').scrollTop() - '5');
 			$('.home').scrollTop($('.home').scrollTop() + '5');
 		}	
+
+		// If the user desires to have favorites highlighted:
+		if(settings.homePageOptions.highlightFavorites){
+			if(cache.highlightLoop != null) {
+				clearInterval(cache.highlightLoop);
+			}
+
+			// Lets keep checking to see if we find any new favorites
+			cache.highlightLoop = setInterval(function(){
+				// Get our current favorites
+				favoriteFriends = settings.generalOptions.favoriteFriends;
+
+				// Checking all streamer cards of non-favorites:
+				$("b-media-card:not('.favoriteFriend')").each(function (index) {
+					// Which streamer did we find
+					var streamer = $(this).find("h2.username").text().replace(/ /g, '').replace(/\r?\n|\r/g, "");
+					
+					if (favoriteFriends != null) {
+						if (favoriteFriends.indexOf(streamer) >= 0) {
+							// If streamer is a favorite, let's highlight the window
+							//log("Found '"+streamer+'"! Highlighting window.')
+							$(this).find("h2.username").addClass("favoriteUsername");
+							$(this).addClass("favoriteFriend");
+						}
+					}
+				});
+			}, 500);
+		} else {
+			// If highlights are off, then let's remove any active highlights.
+			$("b-media-card.favoriteFriend").removeClass("favoriteFriend");
+
+			// clear the loop so were aren't trying to run it constantly!
+			if(cache.highlightLoop != null) {
+				clearInterval(cache.highlightLoop);
+			}
+		}
 	}
 	
 	function loadStreamerPage(streamerName) {
@@ -510,7 +546,8 @@ $(() => {
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.get({
 				'streamerPageOptions': null,
-				'homePageOptions': null
+				'homePageOptions': null,
+				'generalOptions': null
 			  }, (options) => {
 				  console.log(options);
 				resolve(options);	  
@@ -663,12 +700,3 @@ $(() => {
 		}		
 	});
 });
-
-
-
-
-
-
-
-
-

--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -94,6 +94,47 @@ $(() => {
 	
 	function loadHomepage(){
 		log('Loading up settings for homepage');
+
+		// If the user desires to have favorites highlighted:
+		/*if(settings.generalOptions.highlightFavorites){*/
+			// log("Highlighting Favorites is on");
+			// clear the loop so were aren't trying to run it constantly!
+			if(cache.highlightLoop != null) {
+				clearInterval(cache.highlightLoop);
+			}
+
+			// Lets keep checking to see if we find any new favorites
+			cache.highlightLoop = setInterval(function(){
+				// Get our current favorites
+				favoriteFriends = settings.generalOptions.favoriteFriends;
+
+				// Checking all streamer cards of non-favorites:
+				$("b-media-card:not('.favoriteFriend')").each(function (index) {
+					// Which streamer did we find
+					var streamer = $(this).find("h2.username").text().replace(/ /g, '').replace(/\r?\n|\r/g, "");
+					
+					if (streamerIsFavorited(streamer)) {
+						// If streamer is a favorite, let's highlight the window
+						$(this).find("h2.username").addClass("favoriteUsername");
+						$(this).addClass("favoriteFriend");
+					} else {
+						$(this).find("h2.username").removeClass("favoriteUsername");
+						$(this).removeClass("favoriteFriend");
+					}
+				});
+			}, 500);
+		/*} else {
+			log("Highlighting Favorites is off");
+			// If highlights are off, then let's remove any active highlights.
+			$("b-media-card.favoriteFriend").removeClass("favoriteFriend");
+
+			// clear the loop so were aren't trying to run it constantly!
+			if(cache.highlightLoop != null) {
+				clearInterval(cache.highlightLoop);
+			}
+		}*/
+
+		
 	
 		if(!settings.homePageOptions) {
 			log('No home page settings saved.');
@@ -116,45 +157,15 @@ $(() => {
 			$('.home').scrollTop($('.home').scrollTop() - '5');
 			$('.home').scrollTop($('.home').scrollTop() + '5');
 		}	
-
-		// If the user desires to have favorites highlighted:
-		if(settings.generalOptions.highlightFavorites){
-			if(cache.highlightLoop != null) {
-				clearInterval(cache.highlightLoop);
-			}
-
-			// Lets keep checking to see if we find any new favorites
-			cache.highlightLoop = setInterval(function(){
-				// Get our current favorites
-				favoriteFriends = settings.generalOptions.favoriteFriends;
-
-				// Checking all streamer cards of non-favorites:
-				$("b-media-card:not('.favoriteFriend')").each(function (index) {
-					// Which streamer did we find
-					var streamer = $(this).find("h2.username").text().replace(/ /g, '').replace(/\r?\n|\r/g, "");
-					
-					if (streamerIsFavorited(streamer)) {
-						// If streamer is a favorite, let's highlight the window
-						$(this).find("h2.username").addClass("favoriteUsername");
-						$(this).addClass("favoriteFriend");
-					}
-				});
-			}, 500);
-		} else {
-			// If highlights are off, then let's remove any active highlights.
-			$("b-media-card.favoriteFriend").removeClass("favoriteFriend");
-
-			// clear the loop so were aren't trying to run it constantly!
-			if(cache.highlightLoop != null) {
-				clearInterval(cache.highlightLoop);
-			}
-		}
 	}
 
-	function showFavoriteButton(isFavorited) {
+	function addFavoriteButton(isFavorited) {
 		if (isFavorited == "") {
 			isFavorited = false;
 		}
+
+		// Removing the favorite button to avoid any duplication
+		$("#ME_favorite-btn").remove();
 
 		if (isFavorited) {
 			$("div.owner-block h2:first-of-type").addClass("favoriteUsername");
@@ -173,11 +184,7 @@ $(() => {
 			isFavorited = false;
 		}
 
-		// Removing the favorite button to avoid any duplication
-		$("#ME_favorite-btn").remove();
-
 		if (isFavorited) {
-			//
 			$("#ME_favorite-btn").html("&#9733;");
 			$("div.owner-block h2:first-of-type").addClass("favoriteUsername");
 			$("#ME_favorite-btn").addClass("faved");
@@ -215,8 +222,11 @@ $(() => {
 	function loadStreamerPage(streamerName) {
 		log(`Loading streamer page for: ${streamerName}`);
 
-		// If the user desires to have favorites highlighted, we need to active the :
-		if(settings.generalOptions.highlightFavorites){
+		// murfGUY TO DO NOTES:
+			// Was having issues storing a toggle option to activate highlights.
+			// So I've opted to just leave them on permenantly until further development can be done.
+			// This is the original logic gate. Leaving it in for now so I can return to it later.
+		/*if(settings.generalOptions.highlightFavorites){*/
 			log("Starting working on the highlight + fav button");
 
 			// Let's if we are following this person
@@ -227,7 +237,7 @@ $(() => {
 				if (result) {
 					// If the streamer is followed,
 					// Let's show the favorite button, but it's state is based on whether streamed is faved.
-					showFavoriteButton(streamerIsFavorited(streamerName));
+					addFavoriteButton(streamerIsFavorited(streamerName));
 
 					// We now set some actions to the button we just added.
 					// These toggle the favorite status of the streamer, as well the button's state.
@@ -243,11 +253,14 @@ $(() => {
 					// There's stuff to do here that I haven't figured out yet.
 
 					// If not followed, favorite status should be removed automatically.
+					if (streamerIsFavorited(streamerName)) {
+						syncFavorites(removeFavorite(streamerName));
+					}
 
 					// We should also attach an event to the follow button that will make the favorite button appear when a streamer is followed.
 					$('bui-icon[icon="heart-full"]').closest('div.bui-btn-raised').click(function () {
 						log('Now following current streamer!');
-						showFavoriteButton(streamerIsFavorited(streamerName));
+						addFavoriteButton(streamerIsFavorited(streamerName));
 
 						$("#ME_favorite-btn").click( function () {
 							addOrRemoveFavorite(streamerName);
@@ -258,17 +271,13 @@ $(() => {
 					});
 				}
 			});
-
-			
-
-
-			
-
-		} else {
+		/*} else {
 			log("Highlights not active. So we don't do this.")
 			$("div.owner-block h2:first-of-type").removeClass("favoriteUsername");
 			$("#ME_favorite-btn").removeClass("faved");
-		}
+		}*/
+
+		
 	
 		if(!settings.streamerPageOptions) {
 			log('No streamer page settings saved.');
@@ -656,6 +665,7 @@ $(() => {
 	}
 	
 	function getSettings() {
+		log("getSettings()");
 		return new Promise((resolve, reject) => {
 			chrome.storage.sync.get({
 				'streamerPageOptions': null,
@@ -781,8 +791,8 @@ $(() => {
 			// get id and do something with it
 			if (cache.user != null) {
 				var userId = cache.user.id;
-				log("current userID: " + userId);
-				log(`https://mixer.com/api/v1/users/${userId}/follows?fields=token&where=token:eq:${streamerName}`);
+				//log("current userID: " + userId);
+				//log(`https://mixer.com/api/v1/users/${userId}/follows?fields=token&where=token:eq:${streamerName}`);
 
 				var request = new XMLHttpRequest();
 				request.open('GET', `https://mixer.com/api/v1/users/${userId}/follows?fields=token&where=token:eq:${streamerName}`, true);
@@ -841,18 +851,30 @@ $(() => {
 	// Adds or Removes a streamer to the favorite list
 	function addOrRemoveFavorite(streamerName) {
 		favorites = settings.generalOptions.favoriteFriends;
-		if (streamerIsFavorited(streamerName)) {
-			log("Removing: "+streamerName);
-			const index = favorites.indexOf(streamerName);
 
-			if (index !== -1) {
-				favorites.splice(index, 1);
-			}
+		if (streamerIsFavorited(streamerName)) {
+			favorites = removeFavorite(streamerName)
 		} else {
+			log("Adding favorite: "+streamerName);
 			favorites.push(streamerName);
-			log("Adding: "+streamerName);
 		}
 
+		syncFavorites(favorites);
+	}
+
+	function removeFavorite(streamerName) {
+		log("Removing favorite: "+streamerName);
+		favorites = settings.generalOptions.favoriteFriends;
+		const index = favorites.indexOf(streamerName);
+
+		if (index !== -1) {
+			favorites.splice(index, 1);
+		}
+		return favorites;
+	}
+
+	function syncFavorites(favorites) {
+		log("Syncing Favorites list: "+favorites)
 		chrome.storage.sync.set({
 			'generalOptions': {
 				favoriteFriends: favorites

--- a/injected-content/styles.css
+++ b/injected-content/styles.css
@@ -112,12 +112,36 @@ b-notifications.theaterMode {
 
 
 /** Favorite Highlights **/
+/** Favorite Highlights & Favorites UI **/
 b-media-card.favoriteFriend {
     background-color: rgb(15, 175, 39);
 }
 
 .favoriteUsername {
+    color: rgb(90,251,142) !important;
     font-weight: bold;
     font-style: italic;
+}
+
+#ME_favorite-btn {
+    font-size: 18px;
+    cursor: pointer;
+    padding: 6px;
+    color: #999;
+    border: 1px solid rgb(55,66,99);
+    border-radius: 4px;
+    margin-right: 15px;
+    background: rgb(20,24,41);
+}
+
+#ME_favorite-btn.faved {
+    color: rgb(4,117,213);
+    border: 1px solid rgb(66,72,85);
+}
+
+#ME_favorite-btn:hover,
+#ME_favorite-btn.faved:hover {
+    color: rgb(90, 251, 142);
+    border-color: rgb(90, 251, 142);
 }
 /** End Highlights CSS **/

--- a/injected-content/styles.css
+++ b/injected-content/styles.css
@@ -109,3 +109,15 @@ b-notifications.theaterMode {
     padding-top: 0px!important;
 }
 /* End Theater Mode */
+
+
+/** Favorite Highlights **/
+b-media-card.favoriteFriend {
+    background-color: rgb(15, 175, 39);
+}
+
+.favoriteUsername {
+    font-weight: bold;
+    font-style: italic;
+}
+/** End Highlights CSS **/

--- a/injected-content/styles.css
+++ b/injected-content/styles.css
@@ -120,7 +120,6 @@ b-media-card.favoriteFriend {
 .favoriteUsername {
     color: rgb(90,251,142) !important;
     font-weight: bold;
-    font-style: italic;
 }
 
 #ME_favorite-btn {

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
-    "name": "MixrElixr",
+    "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2",
+    "version": "1.2.1.14",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.1.14",
+    "version": "1.2.1.24",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/options/app/components/generalOptions.js
+++ b/options/app/components/generalOptions.js
@@ -8,7 +8,7 @@ Vue.component('general-options', {
 			<div class="option-wrapper">
 				<checkbox-toggle :value.sync="showBadge" @changed="showBadgeChanged()" label="Currently Online Count Badge" tooltip="Whether or not you want the number of currently streaming friends displaying as a badge on the Elixr icon."></checkbox-toggle>
 				
-				<checkbox-toggle :value.sync="highlightFavorites" @changed="showBadgeChanged()" label="Highlight Favorites" tooltip="Marks favorite streamers with green highlights while browsing Mixer."></checkbox-toggle>
+				<checkbox-toggle :value.sync="highlightFavorites" @changed="highlightFavoritesChanged()" label="Highlight Favorites" tooltip="Marks favorite streamers with green highlights while browsing Mixer."></checkbox-toggle>
 
 
 				<div style="padding-bottom: 5px;">Favorite Streamers<option-tooltip name="favorite" title="Any streamers listed here will show up in the favorites list. If any favorite is streaming, the icon badge will be green instead of blue."></option-tooltip></div>

--- a/options/app/components/generalOptions.js
+++ b/options/app/components/generalOptions.js
@@ -7,6 +7,10 @@ Vue.component('general-options', {
 			<div class="settings-section-settings" style="padding-bottom: 0;">
 			<div class="option-wrapper">
 				<checkbox-toggle :value.sync="showBadge" @changed="showBadgeChanged()" label="Currently Online Count Badge" tooltip="Whether or not you want the number of currently streaming friends displaying as a badge on the Elixr icon."></checkbox-toggle>
+				
+				<checkbox-toggle :value.sync="highlightFavorites" @changed="showBadgeChanged()" label="Highlight Favorites" tooltip="Marks favorite streamers with green highlights while browsing Mixer."></checkbox-toggle>
+
+
 				<div style="padding-bottom: 5px;">Favorite Streamers<option-tooltip name="favorite" title="Any streamers listed here will show up in the favorites list. If any favorite is streaming, the icon badge will be green instead of blue."></option-tooltip></div>
 				<edittable-list class="option" :value.sync="favoriteFriends" :options="followingList" tag-placeholder="" placeholder="Search for or select a streamer" @changed="saveSettings()" @add-entry="favoriteAdded" @remove-entry="favoriteRemoved" :auto-close="true"></edittable-list>
 			</div>

--- a/options/app/components/homePageOptions.js
+++ b/options/app/components/homePageOptions.js
@@ -7,9 +7,6 @@ Vue.component('home-page-options', {
 			<div class="settings-section-settings" style="padding-bottom: 0;">
 				<checkbox-toggle :value.sync="removeFeatured" @changed="saveSettings()" label="Remove Featured Streams"></checkbox-toggle>
 			</div>
-			<div class="settings-section-settings" style="padding-bottom: 0;">
-				<checkbox-toggle :value.sync="highlightFavorites" @changed="saveSettings()" label="Highlight Favorites"></checkbox-toggle>
-			</div>
 		</div>
 	`,
 	mixins: [settingsStorage],

--- a/options/app/components/homePageOptions.js
+++ b/options/app/components/homePageOptions.js
@@ -7,6 +7,9 @@ Vue.component('home-page-options', {
 			<div class="settings-section-settings" style="padding-bottom: 0;">
 				<checkbox-toggle :value.sync="removeFeatured" @changed="saveSettings()" label="Remove Featured Streams"></checkbox-toggle>
 			</div>
+			<div class="settings-section-settings" style="padding-bottom: 0;">
+				<checkbox-toggle :value.sync="highlightFavorites" @changed="saveSettings()" label="Highlight Favorites"></checkbox-toggle>
+			</div>
 		</div>
 	`,
 	mixins: [settingsStorage],

--- a/options/app/mixins/settingsStorage.js
+++ b/options/app/mixins/settingsStorage.js
@@ -35,7 +35,7 @@ settingsStorage = {
 		saveGeneralOptions: function(options) {
 			this.saveAllSettings({
 				'generalOptions': options
-			}, false);
+			}, true);
 		},
 		getDefaultOptions: function() {
 			return {
@@ -65,7 +65,7 @@ settingsStorage = {
 				generalOptions: {
 					showBadge: true,
 					favoriteFriends: [],
-					highlightFavorites: false
+					highlightFavorites: true
 				}
 			};
 		},

--- a/options/app/mixins/settingsStorage.js
+++ b/options/app/mixins/settingsStorage.js
@@ -60,12 +60,12 @@ settingsStorage = {
 				},
 				homePageOptions: {
 					removeFeatured: false,
-					autoMute: false,
-					highlightFavorites: false
+					autoMute: false
 				},
 				generalOptions: {
 					showBadge: true,
-					favoriteFriends: []
+					favoriteFriends: [],
+					highlightFavorites: false
 				}
 			};
 		},

--- a/options/app/mixins/settingsStorage.js
+++ b/options/app/mixins/settingsStorage.js
@@ -60,7 +60,8 @@ settingsStorage = {
 				},
 				homePageOptions: {
 					removeFeatured: false,
-					autoMute: false
+					autoMute: false,
+					highlightFavorites: false
 				},
 				generalOptions: {
 					showBadge: true,


### PR DESCRIPTION
#### Requirements

* Filling out the below template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

Adds features related to the ability to provide highlights to favorited streamers while browsing, and to also be able to add/remove favorite streamers from a streamer's personal page.

### Benefits

Users will now be able to easily find their favorite streamers from the browsing, and additionally be able to edit favorite status without needing to visit the options dropdown.

### Possible Drawbacks

This feature cannot be turned off at the moment, and additional development is required to make that an adjustable option for users.

### Applicable Issues

Unfollowing a streamer does not automatically remove their favorite status.
Highlights are only present on browsing page, and streamer pages. Expansions to functionality are planned for additional highlighting in chat and team pages.


> Note:
> Please be aware that we may require changes (in code or in the UI) if we 
> believe they are required to meet the vision and standards of Elixr.
> Don't take suggestions for tweaks personally, we are all simply trying to make Elixr
> the best that it can be :)
