### PR TITLE
Added the ability to auto close costreams

### DIFF
--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -368,6 +368,17 @@ $(() => {
 			});
 			theaterBtn.insertBefore($('.toolbar').children().last());
 		}
+
+        // Auto Close Costreams
+        if(options.autoCloseCostreams){
+            var costreamPage = detectCostreams();
+            if(costreamPage) {
+                log('Costream detected. Waiting for profiles to load')
+                closeCostreams(streamerName);
+            } else {
+                log('No costream detected');
+            }
+        }
 	
 		applyChatSettings(streamerName);
 	}
@@ -381,6 +392,35 @@ $(() => {
 			theaterElements.addClass('theaterMode');
 		}
 	}
+
+    function closeCostreams(streamerName) {        
+        var profile = $('div.profile');
+        if(profile.length === 0) {
+            // Profile divs have not appeared yet
+            setTimeout(closeCostreams, 500, streamerName);
+        } else {
+            // Profile divs have appeared
+            log('Profiles loaded');
+            profile.each(function() {
+                // Check if profile does NOT contain current streamer's name
+                if($(this).is(':not(:contains(' + streamerName + '))')) {
+                    var closeBtn = $(this).siblings().eq(0).children()[2];
+                    if(closeBtn){
+                        closeBtn.click();
+                    }
+                }
+            });
+        }
+    }
+
+    function detectCostreams() {
+        var owners = $('div.owners').find('.head');
+        if(owners.length > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 	
 	function applyChatSettings(streamerName) {
 	

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 2,
-    "name": "MixrElixr-FavHighlights Branch",
+    "name": "MixrElixr-dev",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
     "version": "1.2.1.24",
     "short_name": "Elixr",

--- a/options/app/components/streamerPageOptions.js
+++ b/options/app/components/streamerPageOptions.js
@@ -12,6 +12,7 @@ Vue.component('streamer-page-options', {
 			<div class="settings-section-settings">
 				<span class="setting-subcategory">General</span>
 				<checkbox-toggle :value.sync="autoCloseInteractive" @changed="saveSettings()" label="Auto close Interactive boards"></checkbox-toggle>
+				<checkbox-toggle :value.sync="autoCloseCostreams" @changed="saveSettings()" label="Auto Close Costreams" tooltip="This will close all streamers in a costream except for the streamer whom you are visiting."></checkbox-toggle>
 				<checkbox-toggle :value.sync="autoMute" @changed="saveSettings()" label="Auto Mute Streams"></checkbox-toggle>
 
 				<span class="setting-subcategory">Chat</span>

--- a/options/app/mixins/settingsStorage.js
+++ b/options/app/mixins/settingsStorage.js
@@ -42,6 +42,7 @@ settingsStorage = {
 				streamerPageOptions: {
 					global: {
 						autoCloseInteractive: false,
+						autoCloseCostreams: false,
 						separateChat: false,
 						alternateChatBGColor: false,
 						mentionChatBGColor: false,


### PR DESCRIPTION
### Description of the Change

This adds the option for viewers to automatically close costreams. Firstly, this will detect if the page the viewer is on is a costream. If it is, it will find and click on all close buttons except on the streamer the viewer is visiting. For example, if a viewer is going into a costream with Blossom, Buttercup, Bubbles, and Bob and they went to mixer.com/bubbles, the script will close Blossom, Buttercup, and Bob's streams.

### Benefits

This saves time for people who normally close costreams by automating the process. People with low bandwidth who can't watch more than one stream at a time will benefit from this greatly.

### Possible Drawbacks

This may close too many streamers for a viewer. For example, if they want to visit a 4 person costream and only wish to close 2 of the streams.

### Applicable Issues
1) Once in a blue moon, if the viewer is coming in from the homepage, the script will not detect that the page is a costream. I have not been able to identify why this is case yet.
2) I have not been able to test this because I cannot find applicable streamers in a costream. But, in theory, if we had two streamers, Bob and Billy_Bob, and the viewer visited mixer.com/bob, neither stream would close because the "bob" is in both names.


> Note:
> Please be aware that we may require changes (in code or in the UI) if we 
> believe they are required to meet the vision and standards of Elixr.
> Don't take suggestions for tweaks personally, we are all simply trying to make Elixr
> the best that it can be :)
