### PR TITLE
Highlight Favorites: Fav buttons for co-streams + Co-stream Detection

### DIFF
--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -294,8 +294,8 @@ $(() => {
 							$(".ME_favorite-btn[streamer='"+streamerName+"']").click( function () {
 								streamer = $(this).attr('streamer');
 								log("This is the button for: " + streamer);
-								addOrRemoveFavorite(streamerName);
-								setFavoriteButtonState(streamerIsFavorited(streamerName));
+								addOrRemoveFavorite(streamer);
+								setFavoriteButtonState(streamer, streamerIsFavorited(streamerName));
 							});
 
 							$('bui-icon[icon="heart-full"]').closest('div.bui-btn-raised').off('click');
@@ -314,11 +314,12 @@ $(() => {
 					// This is the current streamer.
 					currentStreamer = $("a.avatar-block:eq("+i+")").attr("href").substr(1);
 					coStreamers.push(currentStreamer);
-					log("CoStreamer #"+(i+1)+": " + currentStreamer);
+					//log("CoStreamer #"+(i+1)+": " + currentStreamer);
 					isFollowed = streamerIsFollowed(currentStreamer);
 
 					isFollowed.then((result) => {
 							streamer = result.streamerName;
+
 							if (result.isFollowed) {
 								// The current streamer is followed 
 								log("Costreamer '" + streamer+"' is followed.");
@@ -335,6 +336,33 @@ $(() => {
 							} else {
 								// The current streamer is not followed
 								log("Costreamer '" + streamer+"' is not followed.");
+
+								// If not followed but is favorited, favorite status should be removed automatically.
+								if (streamerIsFavorited(streamer)) {
+									syncFavorites(removeFavorite(streamer));
+								}
+
+								followButtonElement = $('a.avatar-block[href="/'+streamer+'"]').siblings('div.owner-block').find('div.bui-btn');
+
+								// We should also attach an event to the follow button that will make the favorite button appear when a streamer is followed.
+								followButtonElement.click(function () {
+									//console.log($(this))
+									//console.log($(this).parents('div.head').find('a.avatar-block').attr("href").substr(1));
+
+									thisStreamer = $(this).parents('div.head').find('a.avatar-block').attr("href").substr(1);
+									log('Now following '+thisStreamer);
+
+									addFavoriteButton(thisStreamer, streamerIsFavorited(thisStreamer), true);
+
+									$(".ME_favorite-btn[streamer='"+thisStreamer+"']").click( function () {
+										streamer = $(this).attr('streamer');
+										log("This is the button for: " + streamer);
+										addOrRemoveFavorite(streamer);
+										setFavoriteButtonState(streamer, streamerIsFavorited(streamer), true);
+									});
+
+									followButtonElement.off('click');
+								});
 							}
 					});
 					

--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -165,15 +165,19 @@ $(() => {
 		// Removing the favorite button to avoid any duplication
 		$('.ME_favorite-btn[streamer="'+streamerName+'"]').remove();
 
+		avatarBlock = $('a.avatar-block[href="/'+streamerName+'"]');
+		log('a.avatar-block[href="/'+streamerName+'"]');
+		console.log(avatarBlock);
+		console.log(avatarBlock.attr("href"));
+
 		if (isCostream) {
-			preceedingElement = $('a.avatar-block[href="'+streamerName+'"]').siblings("div.owner-block").find("div.follow-block");
-			userNameTarget = $('a.avatar-block[href="'+streamerName+'"]').siblings("div.owner-block").find("h2:first-of-type");
+			preceedingElement = avatarBlock.siblings("div.owner-block").find("div.follow-block");
+			userNameTarget = avatarBlock.siblings("div.owner-block").find("h2:first-of-type");
 		} else {
 			preceedingElement = $("div.follow-block");
 			userNameTarget = $("div.owner-block h2:first-of-type");
 		}
 
-		console.log($('a.avatar-block[href="'+streamerName+'"]').attr("href"));
 		console.log(preceedingElement);
 		console.log(userNameTarget);
 

--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -897,22 +897,43 @@ $(() => {
 
 	// Returns boolean based on whether or not a streamer is favorited.
 	function streamerIsFavorited(streamerName) {
-		favoriteFriends = settings.generalOptions.favoriteFriends;
+		// If general options is null, we need to create the object so we have something to read the data from.
+		if (settings.generalOptions == null) {
+			settings.generalOptions = {};
+			settings.generalOptions.favoriteFriends = Array();
+		}
 
-		// Is there data in the friends array?
-		if (favoriteFriends != null) {
-			// If there is data, is there anything in it?
-			if (favoriteFriends.indexOf(streamerName) >= 0) {
-				// If streamer is a favorite, then we want.
-				return true;
+		// Are there any favorites?
+		if (settings.generalOptions.favoriteFriends != null) {
+			favoriteFriends = settings.generalOptions.favoriteFriends;
+
+			// Is there data in the friends array?
+			if (favoriteFriends != null) {
+				// If there is data, is there anything in it?
+				if (favoriteFriends.indexOf(streamerName) >= 0) {
+					// If streamer is a favorite, then we want.
+					return true;
+				}
 			}
 		}
+
 		return false;
 	}
 
 	// Adds or Removes a streamer to the favorite list
 	function addOrRemoveFavorite(streamerName) {
 		log("addOrRemoveFavorite("+streamerName+")")
+
+		// If general options is null, we need to create the object so we have something to attach the data to.
+		if (settings.generalOptions == null) {
+			settings.generalOptions = {};
+			settings.generalOptions.favoriteFriends = Array();
+		}
+
+		console.log(settings.generalOptions)
+		console.log(settings.generalOptions.favoriteFriends)
+
+
 		favorites = settings.generalOptions.favoriteFriends;
 
 		if (streamerIsFavorited(streamerName)) {
@@ -923,6 +944,7 @@ $(() => {
 		}
 
 		syncFavorites(favorites);
+		
 	}
 
 	function removeFavorite(streamerName) {

--- a/injected-content/styles.css
+++ b/injected-content/styles.css
@@ -122,7 +122,7 @@ b-media-card.favoriteFriend {
     font-weight: bold;
 }
 
-#ME_favorite-btn {
+.ME_favorite-btn {
     font-size: 18px;
     cursor: pointer;
     padding: 6px;
@@ -133,13 +133,13 @@ b-media-card.favoriteFriend {
     background: rgb(20,24,41);
 }
 
-#ME_favorite-btn.faved {
+.ME_favorite-btn.faved {
     color: rgb(4,117,213);
     border: 1px solid rgb(66,72,85);
 }
 
-#ME_favorite-btn:hover,
-#ME_favorite-btn.faved:hover {
+.ME_favorite-btn:hover,
+.ME_favorite-btn.faved:hover {
     color: rgb(90, 251, 142);
     border-color: rgb(90, 251, 142);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.2.25",
+    "version": "1.2.2.45",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.2.61",
+    "version": "1.2.2.62",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.2.20",
+    "version": "1.2.2.25",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.1.24",
+    "version": "1.2.2.20",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.2.45",
+    "version": "1.2.2.58",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "MixrElixr-FavHighlights Branch",
     "description": "Options and tweaks to improve your Mixer.com viewing experience.",
-    "version": "1.2.2.58",
+    "version": "1.2.2.61",
     "short_name": "Elixr",
     "browser_action": {
         "default_icon": "/resources/images/elixr-light-16.png",


### PR DESCRIPTION
#### Requirements

* Filling out the below template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

This update contains modifications that enable the detection of a co-stream, gets the active set of co-streamers and appropriately places favorite buttons in co-streamer menus based on follow status. All detection of co-stream, co-streamers and their followed status is achieved by way of Mixer API calls. Favorite buttons on co-streams work in the same fashion as solo-streamers for end users.

Functions that were in use for solo-streamer favorite button injection have been modified to understand the required DOM for both solo-streamers and co-stream pages. 

Additional adjustments have been made to help solidify the methods by which favorite buttons are injected and operate in order to appropriately accommodate co-streamer favoriting. And general tidying of function placement, comments and log statements have also been done.

### Benefits

This now enables favoriting from all streamer pages as well as provides a reliable method of co-stream detection that is available to all MixrElixr developers.

### Possible Drawbacks

None that come to mind at present.

### Applicable Issues

No extra development was done on saving of options related to these features. There should be discussion of which related options and features can be toggled.

While co-stream detection functions are open for all developers, their implementation in 'loadStreamerPage' was solely created around the favorite buttons. It would be worth investigating on how best to differentiate and implement co-stream specific injections.

