### PR TITLE
Bug fix for Theater Mode

### DIFF
--- a/injected-content/mixrelixr.js
+++ b/injected-content/mixrelixr.js
@@ -360,7 +360,7 @@ $(() => {
 		if($('[theater-mode-btn-container]').length < 1) {
 
 			//copy the fullscreen button so we can make it into the theater btn
-			let theaterBtn = $('.toolbar').children().last().clone();
+			let theaterBtn = $('.toolbar','.player-controls').children().last().clone();
 
 			//add an attr for us to check for it later
 			theaterBtn.attr('theater-mode-btn-container', '');


### PR DESCRIPTION
#### Requirements

* Filling out the below template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

A bug occurred when visiting the analytics page of an offline stream where where a toolbar was unintentionally duplicated. The theater mode button was present in that toolbar. This change makes sure we only copy the toolbar that is in the player controls.

### Alternate Designs

N/A

### Benefits

A bug is fixed!

### Possible Drawbacks

N/A

### Applicable Issues

N/A
